### PR TITLE
Fixup reference to incorrect variable

### DIFF
--- a/vici/message.go
+++ b/vici/message.go
@@ -833,7 +833,7 @@ func (m *Message) marshalFromStruct(rv reflect.Value) error {
 
 		if mt.inline {
 			if rfv.Kind() != reflect.Struct {
-				return fmt.Errorf("%v: cannot marshal non-struct inlined field %v", errMarshalUnsupportedType, rv.Kind())
+				return fmt.Errorf("%v: cannot marshal non-struct inlined field %v", errMarshalUnsupportedType, rfv.Kind())
 			}
 
 			err := m.marshalFromStruct(rfv)
@@ -958,7 +958,7 @@ func (m *Message) unmarshalToStruct(rv reflect.Value) error {
 
 		if tag.inline {
 			if rfv.Kind() != reflect.Struct {
-				return fmt.Errorf("%v: cannot unmarshal into non-struct inlined field %v", errUnmarshalUnsupportedType, rv.Kind())
+				return fmt.Errorf("%v: cannot unmarshal into non-struct inlined field %v", errUnmarshalUnsupportedType, rfv.Kind())
 			}
 
 			err := m.unmarshalToStruct(rfv)


### PR DESCRIPTION
The inline reflection error message refers to the parent rather than the variable that we're having issues converting. This corrects the issue so that we output the correct type:

From:
cannot unmarshal into non-struct inlined field struct

To:
cannot unmarshal into non-struct inlined field map